### PR TITLE
Graceful shutdown on SIGTERM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.8
+  - 1.11
 
 install:
   - go get github.com/mattn/goveralls golang.org/x/tools/cmd/cover github.com/pierrre/gotestcover github.com/Masterminds/glide github.com/golang/lint/golint golang.org/x/tools/cmd/goimports


### PR DESCRIPTION
Kubernetes sends SIGTERM by default on container termination.

Fixes #3

Signed-off-by: Janis Meybohm <meybohm@traum-ferienwohnungen.de>