### PR TITLE
chore: update repository template to 064b19dd

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -196,6 +196,8 @@ request, go through this checklist:
    command and confirm that it passes.
 1. Run `gofmt -s` (if the project is written in Go).
 1. Ensure that each commit has a subsystem prefix (ex: `controller:`).
+   [List of subsystem prefixes for Graceful](https://github.com/ory/ory/graceful/blob/master/.github/semantic.yml)
+   (if applicable).
 
 Pull requests will be treated as "review requests," and maintainers will give
 feedback on the style and substance of the patch.


### PR DESCRIPTION
Updated repository templates to https://github.com/ory/meta/commit/064b19ddd16977b9a9fba72c3383b967d9f8ad78.