### PR TITLE
fix: listen for SIGINT next to SIGTERM

### DIFF
--- a/http_graceful.go
+++ b/http_graceful.go
@@ -57,7 +57,7 @@ func Graceful(start StartFunc, shutdown ShutdownFunc) error {
 
 	// Setup the graceful shutdown handler (traps SIGINT and SIGTERM)
 	go func() {
-		signal.Notify(stopChan, os.Interrupt, syscall.SIGTERM)
+		signal.Notify(stopChan, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 
 		<-stopChan
 


### PR DESCRIPTION
Currently we only get notified by SIGTERM, but not SIGINT as specified in the documentation.
Pre #4 we were notified on any signal, that's why it worked initially. Took quite a long time for anyone to notice :sweat_smile: 